### PR TITLE
Document usage of serif math font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,5 @@ TSWLatexianTemp*
 
 # End of https://www.toptal.com/developers/gitignore/api/latex
 
+# Not part of this theme, but people may want it and link/copy the file.
+theme/beamerfontthemeserif.sty

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-## Helmholtz AI beamer template
+# Helmholtz AI beamer template
 
-Status
-------
+
+## Status
 
 [![license: BSD-3](https://img.shields.io/badge/License-BSD3-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-Requirements
-------------
+
+## Requirements
 
 Ensure that you have an up-to-date LaTeX distribution installed on your system.
 
@@ -27,8 +27,8 @@ sudo dnf install texlive-scheme-full
 If you don't have sudo access you can install [TeX Live](https://www.tug.org/texlive/) locally.
 Visit the [TeX Live quick install page](https://www.tug.org/texlive/quickinstall.html) for instructions.
 
-Building the slides
--------------------
+
+## Building the slides
 
 In order to build your slides you can use your favorite LaTeX IDE, like TeXstudio, Texmaker or even Overleaf.
 Please ensure that you compile it with XeLaTeX or LuaLaTeX instead of the (usual default) pdfLaTeX.
@@ -60,13 +60,12 @@ latexmk -c slides.tex
 
 Note: At the time of writing, the contents of this repo can be readily used on [overleaf](https://overleaf.com).
 
-License
--------
+
+## License
 
 The Helmholtz AI beamer template is distributed under the BSD-3 license, see our [LICENSE](LICENSE) file for details.
 
-Copyrights
-----------
+
+## Copyrights
 
 The images and fonts provided as part of this LaTeX source code repository are copyrighted. As member of the Helmholtz Association you can freely use the material. For Helmholtz AI external users, you have to ensure that you are allowed to use a) the Helmholtz AI visual material, b) the Helmholtz coporate design as well as c) the Hermann Bold font and Corporate-S font family.
-

--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ latexmk -c slides.tex
 Note: At the time of writing, the contents of this repo can be readily used on [overleaf](https://overleaf.com).
 
 
+### Use standard TeX math font
+
+In order to use the standard serif TeX math font,
+copy or link `/path/to/beamerfontthemeserif.sty` into `theme/`, e.g.
+
+```sh
+$ cd theme
+$ ln -s /usr/share/texlive/texmf-dist/tex/latex/beamer/beamerfontthemeserif.sty beamerfontthemeserif.sty
+```
+
+Then on the TeX side, use
+
+```tex
+\usepackage{lmodern}
+\usefonttheme[onlymath]{serif}
+```
+
 ## License
 
 The Helmholtz AI beamer template is distributed under the BSD-3 license, see our [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Status
 Requirements
 ------------
 
-Ensure that you have an up-to-date LaTeX distribution installed on your system. 
+Ensure that you have an up-to-date LaTeX distribution installed on your system.
 
 *Ubuntu/Debian*
 
@@ -49,13 +49,13 @@ Alternatively, you can use the `latexmk` tool to compile your slides (either in 
 A working `.latexmkrc` is included, simply run the following:
 
 ```bash
-latexmkrc slides.tex
+latexmk slides.tex
 ```
 
 To get rid of all temporary files created during compilation use the `-c` flag (`-C` to also remove the final slides PDF):
 
 ```bash
-latexmkrc -c slides.tex
+latexmk -c slides.tex
 ```
 
 Note: At the time of writing, the contents of this repo can be readily used on [overleaf](https://overleaf.com).

--- a/slides.tex
+++ b/slides.tex
@@ -5,6 +5,14 @@
 \documentclass[aspectratio=1610]{beamer}
 \usepackage{helmholtzai}
 
+% Use standard TeX math font.
+%
+% Copy or link /path/to/beamerfontthemeserif.sty into theme/, e.g.
+%   cd theme
+%   ln -s /usr/share/texlive/texmf-dist/tex/latex/beamer/beamerfontthemeserif.sty beamerfontthemeserif.sty
+%%\usepackage{lmodern}
+%%\usefonttheme[onlymath]{serif}
+
 \title{Title}
 \subtitle{Subtitle}
 \author{Firstname Lastname}
@@ -17,7 +25,7 @@
 
 \begin{frame}
     \frametitle{Usage}
-    
+
     \begin{enumerate}
         \item Download all files from Github\\~
         \item Edit \texttt{slides.tex} with your favorite editor\\~
@@ -26,14 +34,14 @@
             \item Typing \texttt{make} or \texttt{latexmk} in the directory of \texttt{slides.tex} or\\~
             \item Using a LaTeX IDE like TeXstudio\\~
         \end{enumerate}
-		\item \emph{Note:} make sure to use LuaLaTeX or XeLaTeX (default in \texttt{make}/\texttt{latexmk}) as compiler 
+        \item \emph{Note:} make sure to use LuaLaTeX or XeLaTeX (default in \texttt{make}/\texttt{latexmk}) as compiler
     \end{enumerate}
 \end{frame}
 
 \begin{frame}
     \frametitle{Main Slide Title}
     \framesubtitle{\textbf{Subtitle} with more \emph{details}}
-    
+
     \begin{itemize}
         \item Standard bullet point can be created with the \texttt{itemize} environment
         \item They can have multiple sub-point
@@ -79,9 +87,9 @@
 
 \begin{frame}[fragile]
     \frametitle{Code}
-    
+
     \emph{Note the [fragile] specifier next to frame and the code indentation.}
-    
+
 \begin{lstlisting}[language=Python]
 import numpy as np
 
@@ -99,9 +107,9 @@ def foo(a, b):
 \begin{frame}
     \frametitle{Colors}
     \framesubtitle{Basic Definitions}
-    
+
     \emph{The beamer template contains definitions for all Helmholtz colors.}\\
-    
+
     \begin{table}
         \centering
         \small
@@ -124,9 +132,9 @@ def foo(a, b):
 \begin{frame}
     \frametitle{Colors}
     \framesubtitle{Shades}
-    
+
     \emph{For each color there exist 10 lighter shades, exemplary for hgfblue}\\
-    
+
     \begin{table}
         \centering
         \small
@@ -148,7 +156,7 @@ def foo(a, b):
 
 \begin{frame}
     \frametitle{Blocks}
-    
+
     \begin{block}{block}
         This is how a regular block looks like
     \end{block}
@@ -164,7 +172,7 @@ def foo(a, b):
 
 \begin{frame}
     \frametitle{Special Formatting}
-    
+
     \begin{itemize}
         \item There are raw links with the full URL \url{https://www.google.com}
         \item You can add also links with names \href{https://www.google.com}{Google}\\~


### PR DESCRIPTION
Also fix README typo `latexmkrc slides.tex` -> `latexmk slides.tex`.